### PR TITLE
Plugin breaks when choosing gray color

### DIFF
--- a/github-ribbon.php
+++ b/github-ribbon.php
@@ -432,8 +432,8 @@ Class GithubRibbonType {
     const ORANGE_LEFT = 6;
     const ORANGE_RIGHT = 7;
 
-    const GREY_LEFT = 8;
-    const GREY_RIGHT = 9;
+    const GRAY_LEFT = 8;
+    const GRAY_RIGHT = 9;
 
     const WHITE_LEFT = 10;
     const WHITE_RIGHT = 11;


### PR DESCRIPTION
I have fixed an inconsistency in the spelling of GRAY/GREY. This bug broke the plugin when selecting the color gray.
