### PR TITLE
Changed to show meta box on all public post types

### DIFF
--- a/github-ribbon.php
+++ b/github-ribbon.php
@@ -99,10 +99,22 @@ class GithubRibbon {
      */
     function add_custom_box() {
 
-        add_meta_box( 'github_ribbon_box', __( 'Github Ribbon', 'github-ribbon' ),
-                    array(&$this, 'inner_custom_box'), 'post', 'side' );
-        add_meta_box( 'github_ribbon_box', __( 'Github Ribbon', 'github-ribbon' ),
-                    array(&$this, 'inner_custom_box'), 'page', 'side' );
+        $post_types = get_post_types( array(
+		    'public' => true
+	    ) );
+
+        foreach ( $post_types as $post_type ) {
+
+	        add_meta_box(
+		        'github_ribbon_box',
+		        __( 'Github Ribbon', 'github-ribbon' ),
+		        array(&$this, 'inner_custom_box'),
+		        $post_type,
+		        'side'
+	        );
+
+        }
+        
     }
 
     /**


### PR DESCRIPTION
Change so that UI is shown for all public post types.

Tested on PHP 5.3.29+, WordPress 4.1.1